### PR TITLE
fix non-determenistic routing behaviour

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/makasim/httprouter
+module github.com/SuddenGunter/httprouter
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/SuddenGunter/httprouter
+module github.com/makasim/httprouter
 
 go 1.18
 

--- a/radix/node.go
+++ b/radix/node.go
@@ -139,13 +139,11 @@ func (n Node) Insert(path string, key uint64) Node {
 		return n
 	}
 
-	n.children = append([]Node{
-		{
-			path:     path,
-			key:      key,
-			children: nil,
-		},
-	}, n.children...)
+	n.children = append(n.children, Node{
+		path:     path,
+		key:      key,
+		children: nil,
+	})
 	return n
 }
 

--- a/radix/node_insert_test.go
+++ b/radix/node_insert_test.go
@@ -6,558 +6,558 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// func TestNode_InsertStatic(main *testing.T) {
-// 	type test struct {
-// 		node       Node
-// 		insertPath string
-// 		insertKey  uint64
-// 		expected   Node
-// 	}
+func TestNode_InsertStatic(main *testing.T) {
+	type test struct {
+		node       Node
+		insertPath string
+		insertKey  uint64
+		expected   Node
+	}
 
-// 	tests := map[string]test{
-// 		"ToEmpty": {
-// 			node:       Node{},
-// 			insertPath: "/foo",
-// 			insertKey:  1,
-// 			expected: Node{
-// 				path: "/foo",
-// 				key:  1,
-// 			},
-// 		},
-// 		"SplitCurrent": {
-// 			node: Node{
-// 				path: "/foo",
-// 				key:  1,
-// 			},
-// 			insertPath: "/faa",
-// 			insertKey:  2,
-// 			expected: Node{
-// 				path: "/f",
-// 				key:  0,
-// 				children: []Node{
-// 					{path: "aa", key: 2},
-// 					{path: "oo", key: 1},
-// 				},
-// 			},
-// 		},
-// 		"ShorterAsCurrent": {
-// 			node:       Node{path: "/foo", key: 1},
-// 			insertPath: "/fo",
-// 			insertKey:  2,
-// 			expected: Node{
-// 				path: "/fo",
-// 				key:  2,
-// 				children: []Node{
-// 					{path: "o", key: 1},
-// 				},
-// 			},
-// 		},
-// 		"SameAsCurrent": {
-// 			node:       Node{path: "/foo", key: 1},
-// 			insertPath: "/foo",
-// 			insertKey:  1,
-// 			expected: Node{
-// 				path: "/foo",
-// 				key:  1,
-// 			},
-// 		},
-// 		"NewChild": {
-// 			node: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{path: "foo", key: 1},
-// 					{path: "bar", key: 2},
-// 				},
-// 			},
-// 			insertPath: "/ololo",
-// 			insertKey:  3,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{path: "ololo", key: 3},
-// 					{path: "foo", key: 1},
-// 					{path: "bar", key: 2},
-// 				},
-// 			},
-// 		},
-// 		"SplitChild": {
-// 			node: Node{
-// 				path: "/",
-// 				key:  0,
-// 				children: []Node{
-// 					{
-// 						path: "foo",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 			insertPath: "/faa",
-// 			insertKey:  2,
-// 			expected: Node{
-// 				path: "/",
-// 				key:  0,
-// 				children: []Node{
-// 					{
-// 						path: "f",
-// 						key:  0,
-// 						children: []Node{
-// 							{
-// 								path: "aa",
-// 								key:  2,
-// 							},
-// 							{
-// 								path: "oo",
-// 								key:  1,
-// 							},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"ShorterChild": {
-// 			node: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{path: "foo", key: 1},
-// 				},
-// 			},
-// 			insertPath: "/fo",
-// 			insertKey:  3,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						path: "fo",
-// 						key:  3,
-// 						children: []Node{
-// 							{
-// 								path: "o",
-// 								key:  1,
-// 							},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"SameChild": {
-// 			node: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{path: "foo", key: 1},
-// 				},
-// 			},
-// 			insertPath: "/foo",
-// 			insertKey:  1,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						path: "foo",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"Bug1": {
-// 			node: Node{
-// 				path: "insert/10",
-// 				children: []Node{
-// 					{
-// 						path: "10",
-// 						key:  1010,
-// 					},
-// 					{
-// 						path: "0",
-// 						children: []Node{
-// 							{path: "9", key: 1009},
-// 						},
-// 					},
-// 				},
-// 			},
-// 			insertPath: "insert/1011",
-// 			insertKey:  1011,
-// 			expected: Node{
-// 				path: "insert/10",
-// 				children: []Node{
-// 					{
-// 						path: "1",
-// 						children: []Node{
-// 							{path: "1", key: 1011},
-// 							{path: "0", key: 1010},
-// 						},
-// 					},
-// 					{
-// 						path: "0",
-// 						children: []Node{
-// 							{path: "9", key: 1009},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"Bug2": {
-// 			node: Node{
-// 				path: "insert/10",
-// 				children: []Node{
-// 					{
-// 						path: "1",
-// 						children: []Node{
-// 							{path: "0", key: 1010},
-// 							{path: "2", key: 1012},
-// 						},
-// 					},
-// 					{
-// 						path: "00",
-// 						key:  1000,
-// 					},
-// 				},
-// 			},
-// 			insertPath: "insert/1011",
-// 			insertKey:  1011,
-// 			expected: Node{
-// 				path: "insert/10",
-// 				children: []Node{
-// 					{
-// 						path: "1",
-// 						children: []Node{
-// 							{path: "1", key: 1011},
-// 							{path: "0", key: 1010},
-// 							{path: "2", key: 1012},
-// 						},
-// 					},
-// 					{
-// 						path: "00",
-// 						key:  1000,
-// 					},
-// 				},
-// 			},
-// 		},
-// 	}
+	tests := map[string]test{
+		"ToEmpty": {
+			node:       Node{},
+			insertPath: "/foo",
+			insertKey:  1,
+			expected: Node{
+				path: "/foo",
+				key:  1,
+			},
+		},
+		"SplitCurrent": {
+			node: Node{
+				path: "/foo",
+				key:  1,
+			},
+			insertPath: "/faa",
+			insertKey:  2,
+			expected: Node{
+				path: "/f",
+				key:  0,
+				children: []Node{
+					{path: "oo", key: 1},
+					{path: "aa", key: 2},
+				},
+			},
+		},
+		"ShorterAsCurrent": {
+			node:       Node{path: "/foo", key: 1},
+			insertPath: "/fo",
+			insertKey:  2,
+			expected: Node{
+				path: "/fo",
+				key:  2,
+				children: []Node{
+					{path: "o", key: 1},
+				},
+			},
+		},
+		"SameAsCurrent": {
+			node:       Node{path: "/foo", key: 1},
+			insertPath: "/foo",
+			insertKey:  1,
+			expected: Node{
+				path: "/foo",
+				key:  1,
+			},
+		},
+		"NewChild": {
+			node: Node{
+				path: "/",
+				children: []Node{
+					{path: "foo", key: 1},
+					{path: "bar", key: 2},
+				},
+			},
+			insertPath: "/ololo",
+			insertKey:  3,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{path: "foo", key: 1},
+					{path: "bar", key: 2},
+					{path: "ololo", key: 3},
+				},
+			},
+		},
+		"SplitChild": {
+			node: Node{
+				path: "/",
+				key:  0,
+				children: []Node{
+					{
+						path: "foo",
+						key:  1,
+					},
+				},
+			},
+			insertPath: "/faa",
+			insertKey:  2,
+			expected: Node{
+				path: "/",
+				key:  0,
+				children: []Node{
+					{
+						path: "f",
+						key:  0,
+						children: []Node{
+							{
+								path: "oo",
+								key:  1,
+							},
+							{
+								path: "aa",
+								key:  2,
+							},
+						},
+					},
+				},
+			},
+		},
+		"ShorterChild": {
+			node: Node{
+				path: "/",
+				children: []Node{
+					{path: "foo", key: 1},
+				},
+			},
+			insertPath: "/fo",
+			insertKey:  3,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{
+						path: "fo",
+						key:  3,
+						children: []Node{
+							{
+								path: "o",
+								key:  1,
+							},
+						},
+					},
+				},
+			},
+		},
+		"SameChild": {
+			node: Node{
+				path: "/",
+				children: []Node{
+					{path: "foo", key: 1},
+				},
+			},
+			insertPath: "/foo",
+			insertKey:  1,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{
+						path: "foo",
+						key:  1,
+					},
+				},
+			},
+		},
+		"Bug1": {
+			node: Node{
+				path: "insert/10",
+				children: []Node{
+					{
+						path: "10",
+						key:  1010,
+					},
+					{
+						path: "0",
+						children: []Node{
+							{path: "9", key: 1009},
+						},
+					},
+				},
+			},
+			insertPath: "insert/1011",
+			insertKey:  1011,
+			expected: Node{
+				path: "insert/10",
+				children: []Node{
+					{
+						path: "1",
+						children: []Node{
+							{path: "0", key: 1010},
+							{path: "1", key: 1011},
+						},
+					},
+					{
+						path: "0",
+						children: []Node{
+							{path: "9", key: 1009},
+						},
+					},
+				},
+			},
+		},
+		"Bug2": {
+			node: Node{
+				path: "insert/10",
+				children: []Node{
+					{
+						path: "1",
+						children: []Node{
+							{path: "0", key: 1010},
+							{path: "2", key: 1012},
+						},
+					},
+					{
+						path: "00",
+						key:  1000,
+					},
+				},
+			},
+			insertPath: "insert/1011",
+			insertKey:  1011,
+			expected: Node{
+				path: "insert/10",
+				children: []Node{
+					{
+						path: "1",
+						children: []Node{
+							{path: "0", key: 1010},
+							{path: "2", key: 1012},
+							{path: "1", key: 1011},
+						},
+					},
+					{
+						path: "00",
+						key:  1000,
+					},
+				},
+			},
+		},
+	}
 
-// 	for name, tt := range tests {
-// 		tt := tt
-// 		main.Run(name, func(t *testing.T) {
-// 			actual := tt.node.Insert(tt.insertPath, tt.insertKey)
-// 			require.Equal(t, tt.expected, actual)
-// 		})
-// 	}
-// }
+	for name, tt := range tests {
+		tt := tt
+		main.Run(name, func(t *testing.T) {
+			actual := tt.node.Insert(tt.insertPath, tt.insertKey)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
 
-// func TestNode_InsertDynamic(main *testing.T) {
-// 	type test struct {
-// 		node       Node
-// 		insertPath string
-// 		insertKey  uint64
-// 		expected   Node
-// 	}
+func TestNode_InsertDynamic(main *testing.T) {
+	type test struct {
+		node       Node
+		insertPath string
+		insertKey  uint64
+		expected   Node
+	}
 
-// 	tests := map[string]test{
-// 		"ToEmpty0": {
-// 			node:       Node{},
-// 			insertPath: "/{foo}",
-// 			insertKey:  1,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{foo}",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"ToEmpty1": {
-// 			node:       Node{},
-// 			insertPath: "/foo/{bar}",
-// 			insertKey:  1,
-// 			expected: Node{
-// 				path: "/foo/",
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{bar}",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"ToEmpty2": {
-// 			node:       Node{},
-// 			insertPath: "/foo/{bar}/baz",
-// 			insertKey:  1,
-// 			expected: Node{
-// 				path: "/foo/",
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{bar}",
-// 						children: []Node{
-// 							{
-// 								path: "/baz",
-// 								key:  1,
-// 							},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"SplitCurrent": {
-// 			node: Node{
-// 				path: "/foo/bar",
-// 				key:  1,
-// 			},
-// 			insertPath: "/foo/{name}",
-// 			insertKey:  2,
-// 			expected: Node{
-// 				path: "/foo/",
-// 				key:  0,
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{name}",
-// 						key:  2,
-// 					},
-// 					{
-// 						path: "bar",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"SplitCurrentParam": {
-// 			node: Node{
-// 				path: "/foo/",
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{bar}",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 			insertPath: "/foo/{bar}/name",
-// 			insertKey:  2,
-// 			expected: Node{
-// 				path: "/foo/",
-// 				key:  0,
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{bar}",
-// 						key:  1,
-// 						children: []Node{
-// 							{
-// 								path: "/name",
-// 								key:  2,
-// 							},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"ShorterAsCurrent": {
-// 			node: Node{
-// 				path: "/",
-// 				key:  0,
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{foo}",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 			insertPath: "/fo",
-// 			insertKey:  2,
-// 			expected: Node{
-// 				path: "/",
-// 				key:  0,
-// 				children: []Node{
-// 					{
-// 						path: "fo",
-// 						key:  2,
-// 					},
-// 					{
-// 						kind: param,
-// 						path: "{foo}",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"SameAsCurrent": {
-// 			node: Node{
-// 				path: "/",
-// 				key:  0,
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{foo}",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 			insertPath: "/{foo}",
-// 			insertKey:  1,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{foo}",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"NewParamChild": {
-// 			node: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{path: "foo", key: 1},
-// 					{path: "bar", key: 2},
-// 				},
-// 			},
-// 			insertPath: "/{ololo}",
-// 			insertKey:  3,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{kind: param, path: "{ololo}", key: 3},
-// 					{path: "foo", key: 1},
-// 					{path: "bar", key: 2},
-// 				},
-// 			},
-// 		},
-// 		"NewParamChildChild1": {
-// 			node: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						path: "foo/",
-// 						key:  1,
-// 						children: []Node{
-// 							{path: "bar", key: 2},
-// 						},
-// 					},
-// 				},
-// 			},
-// 			insertPath: "/foo/{ololo}",
-// 			insertKey:  3,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						path: "foo/",
-// 						key:  1,
-// 						children: []Node{
-// 							{kind: param, path: "{ololo}", key: 3},
-// 							{path: "bar", key: 2},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"NewParamChildChild2": {
-// 			node: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						path: "foo/",
-// 						key:  1,
-// 						children: []Node{
-// 							{path: "bar", key: 2},
-// 						},
-// 					},
-// 				},
-// 			},
-// 			insertPath: "/foo/{ololo}/aaa",
-// 			insertKey:  3,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						path: "foo/",
-// 						key:  1,
-// 						children: []Node{
-// 							{
-// 								kind: param,
-// 								path: "{ololo}",
-// 								children: []Node{
-// 									{
-// 										path: "/aaa",
-// 										key:  3,
-// 									},
-// 								},
-// 							},
-// 							{path: "bar", key: 2},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"NewParamChildChild3": {
-// 			node: Node{
-// 				path: "/bar/",
-// 				children: []Node{
-// 					{
-// 						path: "1",
-// 						key:  2,
-// 					},
-// 					{
-// 						path: "0",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 			insertPath: "/bar/{param}",
-// 			insertKey:  3,
-// 			expected: Node{
-// 				path: "/bar/",
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{param}",
-// 						key:  3,
-// 					},
-// 					{
-// 						path: "1",
-// 						key:  2,
-// 					},
-// 					{
-// 						path: "0",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 		"Wildcard": {
-// 			node:       Node{},
-// 			insertPath: "/{*foo}",
-// 			insertKey:  1,
-// 			expected: Node{
-// 				path: "/",
-// 				children: []Node{
-// 					{
-// 						kind: param,
-// 						path: "{*foo}",
-// 						key:  1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 	}
+	tests := map[string]test{
+		"ToEmpty0": {
+			node:       Node{},
+			insertPath: "/{foo}",
+			insertKey:  1,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{
+						kind: param,
+						path: "{foo}",
+						key:  1,
+					},
+				},
+			},
+		},
+		"ToEmpty1": {
+			node:       Node{},
+			insertPath: "/foo/{bar}",
+			insertKey:  1,
+			expected: Node{
+				path: "/foo/",
+				children: []Node{
+					{
+						kind: param,
+						path: "{bar}",
+						key:  1,
+					},
+				},
+			},
+		},
+		"ToEmpty2": {
+			node:       Node{},
+			insertPath: "/foo/{bar}/baz",
+			insertKey:  1,
+			expected: Node{
+				path: "/foo/",
+				children: []Node{
+					{
+						kind: param,
+						path: "{bar}",
+						children: []Node{
+							{
+								path: "/baz",
+								key:  1,
+							},
+						},
+					},
+				},
+			},
+		},
+		"SplitCurrent": {
+			node: Node{
+				path: "/foo/bar",
+				key:  1,
+			},
+			insertPath: "/foo/{name}",
+			insertKey:  2,
+			expected: Node{
+				path: "/foo/",
+				key:  0,
+				children: []Node{
+					{
+						kind: param,
+						path: "{name}",
+						key:  2,
+					},
+					{
+						path: "bar",
+						key:  1,
+					},
+				},
+			},
+		},
+		"SplitCurrentParam": {
+			node: Node{
+				path: "/foo/",
+				children: []Node{
+					{
+						kind: param,
+						path: "{bar}",
+						key:  1,
+					},
+				},
+			},
+			insertPath: "/foo/{bar}/name",
+			insertKey:  2,
+			expected: Node{
+				path: "/foo/",
+				key:  0,
+				children: []Node{
+					{
+						kind: param,
+						path: "{bar}",
+						key:  1,
+						children: []Node{
+							{
+								path: "/name",
+								key:  2,
+							},
+						},
+					},
+				},
+			},
+		},
+		"ShorterAsCurrent": {
+			node: Node{
+				path: "/",
+				key:  0,
+				children: []Node{
+					{
+						kind: param,
+						path: "{foo}",
+						key:  1,
+					},
+				},
+			},
+			insertPath: "/fo",
+			insertKey:  2,
+			expected: Node{
+				path: "/",
+				key:  0,
+				children: []Node{
+					{
+						kind: param,
+						path: "{foo}",
+						key:  1,
+					},
+					{
+						path: "fo",
+						key:  2,
+					},
+				},
+			},
+		},
+		"SameAsCurrent": {
+			node: Node{
+				path: "/",
+				key:  0,
+				children: []Node{
+					{
+						kind: param,
+						path: "{foo}",
+						key:  1,
+					},
+				},
+			},
+			insertPath: "/{foo}",
+			insertKey:  1,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{
+						kind: param,
+						path: "{foo}",
+						key:  1,
+					},
+				},
+			},
+		},
+		"NewParamChild": {
+			node: Node{
+				path: "/",
+				children: []Node{
+					{path: "foo", key: 1},
+					{path: "bar", key: 2},
+				},
+			},
+			insertPath: "/{ololo}",
+			insertKey:  3,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{kind: param, path: "{ololo}", key: 3},
+					{path: "foo", key: 1},
+					{path: "bar", key: 2},
+				},
+			},
+		},
+		"NewParamChildChild1": {
+			node: Node{
+				path: "/",
+				children: []Node{
+					{
+						path: "foo/",
+						key:  1,
+						children: []Node{
+							{path: "bar", key: 2},
+						},
+					},
+				},
+			},
+			insertPath: "/foo/{ololo}",
+			insertKey:  3,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{
+						path: "foo/",
+						key:  1,
+						children: []Node{
+							{kind: param, path: "{ololo}", key: 3},
+							{path: "bar", key: 2},
+						},
+					},
+				},
+			},
+		},
+		"NewParamChildChild2": {
+			node: Node{
+				path: "/",
+				children: []Node{
+					{
+						path: "foo/",
+						key:  1,
+						children: []Node{
+							{path: "bar", key: 2},
+						},
+					},
+				},
+			},
+			insertPath: "/foo/{ololo}/aaa",
+			insertKey:  3,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{
+						path: "foo/",
+						key:  1,
+						children: []Node{
+							{
+								kind: param,
+								path: "{ololo}",
+								children: []Node{
+									{
+										path: "/aaa",
+										key:  3,
+									},
+								},
+							},
+							{path: "bar", key: 2},
+						},
+					},
+				},
+			},
+		},
+		"NewParamChildChild3": {
+			node: Node{
+				path: "/bar/",
+				children: []Node{
+					{
+						path: "1",
+						key:  2,
+					},
+					{
+						path: "0",
+						key:  1,
+					},
+				},
+			},
+			insertPath: "/bar/{param}",
+			insertKey:  3,
+			expected: Node{
+				path: "/bar/",
+				children: []Node{
+					{
+						kind: param,
+						path: "{param}",
+						key:  3,
+					},
+					{
+						path: "1",
+						key:  2,
+					},
+					{
+						path: "0",
+						key:  1,
+					},
+				},
+			},
+		},
+		"Wildcard": {
+			node:       Node{},
+			insertPath: "/{*foo}",
+			insertKey:  1,
+			expected: Node{
+				path: "/",
+				children: []Node{
+					{
+						kind: param,
+						path: "{*foo}",
+						key:  1,
+					},
+				},
+			},
+		},
+	}
 
-// 	for name, tt := range tests {
-// 		tt := tt
+	for name, tt := range tests {
+		tt := tt
 
-// 		main.Run(name, func(t *testing.T) {
-// 			actual := tt.node.Insert(tt.insertPath, tt.insertKey)
-// 			require.Equal(t, tt.expected, actual)
-// 		})
-// 	}
-// }
+		main.Run(name, func(t *testing.T) {
+			actual := tt.node.Insert(tt.insertPath, tt.insertKey)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
 
 func TestNode_InsertInvalid(main *testing.T) {
 	n := Node{}

--- a/radix/node_insert_test.go
+++ b/radix/node_insert_test.go
@@ -6,558 +6,558 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNode_InsertStatic(main *testing.T) {
-	type test struct {
-		node       Node
-		insertPath string
-		insertKey  uint64
-		expected   Node
-	}
+// func TestNode_InsertStatic(main *testing.T) {
+// 	type test struct {
+// 		node       Node
+// 		insertPath string
+// 		insertKey  uint64
+// 		expected   Node
+// 	}
 
-	tests := map[string]test{
-		"ToEmpty": {
-			node:       Node{},
-			insertPath: "/foo",
-			insertKey:  1,
-			expected: Node{
-				path: "/foo",
-				key:  1,
-			},
-		},
-		"SplitCurrent": {
-			node: Node{
-				path: "/foo",
-				key:  1,
-			},
-			insertPath: "/faa",
-			insertKey:  2,
-			expected: Node{
-				path: "/f",
-				key:  0,
-				children: []Node{
-					{path: "aa", key: 2},
-					{path: "oo", key: 1},
-				},
-			},
-		},
-		"ShorterAsCurrent": {
-			node:       Node{path: "/foo", key: 1},
-			insertPath: "/fo",
-			insertKey:  2,
-			expected: Node{
-				path: "/fo",
-				key:  2,
-				children: []Node{
-					{path: "o", key: 1},
-				},
-			},
-		},
-		"SameAsCurrent": {
-			node:       Node{path: "/foo", key: 1},
-			insertPath: "/foo",
-			insertKey:  1,
-			expected: Node{
-				path: "/foo",
-				key:  1,
-			},
-		},
-		"NewChild": {
-			node: Node{
-				path: "/",
-				children: []Node{
-					{path: "foo", key: 1},
-					{path: "bar", key: 2},
-				},
-			},
-			insertPath: "/ololo",
-			insertKey:  3,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{path: "ololo", key: 3},
-					{path: "foo", key: 1},
-					{path: "bar", key: 2},
-				},
-			},
-		},
-		"SplitChild": {
-			node: Node{
-				path: "/",
-				key:  0,
-				children: []Node{
-					{
-						path: "foo",
-						key:  1,
-					},
-				},
-			},
-			insertPath: "/faa",
-			insertKey:  2,
-			expected: Node{
-				path: "/",
-				key:  0,
-				children: []Node{
-					{
-						path: "f",
-						key:  0,
-						children: []Node{
-							{
-								path: "aa",
-								key:  2,
-							},
-							{
-								path: "oo",
-								key:  1,
-							},
-						},
-					},
-				},
-			},
-		},
-		"ShorterChild": {
-			node: Node{
-				path: "/",
-				children: []Node{
-					{path: "foo", key: 1},
-				},
-			},
-			insertPath: "/fo",
-			insertKey:  3,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{
-						path: "fo",
-						key:  3,
-						children: []Node{
-							{
-								path: "o",
-								key:  1,
-							},
-						},
-					},
-				},
-			},
-		},
-		"SameChild": {
-			node: Node{
-				path: "/",
-				children: []Node{
-					{path: "foo", key: 1},
-				},
-			},
-			insertPath: "/foo",
-			insertKey:  1,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{
-						path: "foo",
-						key:  1,
-					},
-				},
-			},
-		},
-		"Bug1": {
-			node: Node{
-				path: "insert/10",
-				children: []Node{
-					{
-						path: "10",
-						key:  1010,
-					},
-					{
-						path: "0",
-						children: []Node{
-							{path: "9", key: 1009},
-						},
-					},
-				},
-			},
-			insertPath: "insert/1011",
-			insertKey:  1011,
-			expected: Node{
-				path: "insert/10",
-				children: []Node{
-					{
-						path: "1",
-						children: []Node{
-							{path: "1", key: 1011},
-							{path: "0", key: 1010},
-						},
-					},
-					{
-						path: "0",
-						children: []Node{
-							{path: "9", key: 1009},
-						},
-					},
-				},
-			},
-		},
-		"Bug2": {
-			node: Node{
-				path: "insert/10",
-				children: []Node{
-					{
-						path: "1",
-						children: []Node{
-							{path: "0", key: 1010},
-							{path: "2", key: 1012},
-						},
-					},
-					{
-						path: "00",
-						key:  1000,
-					},
-				},
-			},
-			insertPath: "insert/1011",
-			insertKey:  1011,
-			expected: Node{
-				path: "insert/10",
-				children: []Node{
-					{
-						path: "1",
-						children: []Node{
-							{path: "1", key: 1011},
-							{path: "0", key: 1010},
-							{path: "2", key: 1012},
-						},
-					},
-					{
-						path: "00",
-						key:  1000,
-					},
-				},
-			},
-		},
-	}
+// 	tests := map[string]test{
+// 		"ToEmpty": {
+// 			node:       Node{},
+// 			insertPath: "/foo",
+// 			insertKey:  1,
+// 			expected: Node{
+// 				path: "/foo",
+// 				key:  1,
+// 			},
+// 		},
+// 		"SplitCurrent": {
+// 			node: Node{
+// 				path: "/foo",
+// 				key:  1,
+// 			},
+// 			insertPath: "/faa",
+// 			insertKey:  2,
+// 			expected: Node{
+// 				path: "/f",
+// 				key:  0,
+// 				children: []Node{
+// 					{path: "aa", key: 2},
+// 					{path: "oo", key: 1},
+// 				},
+// 			},
+// 		},
+// 		"ShorterAsCurrent": {
+// 			node:       Node{path: "/foo", key: 1},
+// 			insertPath: "/fo",
+// 			insertKey:  2,
+// 			expected: Node{
+// 				path: "/fo",
+// 				key:  2,
+// 				children: []Node{
+// 					{path: "o", key: 1},
+// 				},
+// 			},
+// 		},
+// 		"SameAsCurrent": {
+// 			node:       Node{path: "/foo", key: 1},
+// 			insertPath: "/foo",
+// 			insertKey:  1,
+// 			expected: Node{
+// 				path: "/foo",
+// 				key:  1,
+// 			},
+// 		},
+// 		"NewChild": {
+// 			node: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{path: "foo", key: 1},
+// 					{path: "bar", key: 2},
+// 				},
+// 			},
+// 			insertPath: "/ololo",
+// 			insertKey:  3,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{path: "ololo", key: 3},
+// 					{path: "foo", key: 1},
+// 					{path: "bar", key: 2},
+// 				},
+// 			},
+// 		},
+// 		"SplitChild": {
+// 			node: Node{
+// 				path: "/",
+// 				key:  0,
+// 				children: []Node{
+// 					{
+// 						path: "foo",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 			insertPath: "/faa",
+// 			insertKey:  2,
+// 			expected: Node{
+// 				path: "/",
+// 				key:  0,
+// 				children: []Node{
+// 					{
+// 						path: "f",
+// 						key:  0,
+// 						children: []Node{
+// 							{
+// 								path: "aa",
+// 								key:  2,
+// 							},
+// 							{
+// 								path: "oo",
+// 								key:  1,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"ShorterChild": {
+// 			node: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{path: "foo", key: 1},
+// 				},
+// 			},
+// 			insertPath: "/fo",
+// 			insertKey:  3,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						path: "fo",
+// 						key:  3,
+// 						children: []Node{
+// 							{
+// 								path: "o",
+// 								key:  1,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"SameChild": {
+// 			node: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{path: "foo", key: 1},
+// 				},
+// 			},
+// 			insertPath: "/foo",
+// 			insertKey:  1,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						path: "foo",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"Bug1": {
+// 			node: Node{
+// 				path: "insert/10",
+// 				children: []Node{
+// 					{
+// 						path: "10",
+// 						key:  1010,
+// 					},
+// 					{
+// 						path: "0",
+// 						children: []Node{
+// 							{path: "9", key: 1009},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			insertPath: "insert/1011",
+// 			insertKey:  1011,
+// 			expected: Node{
+// 				path: "insert/10",
+// 				children: []Node{
+// 					{
+// 						path: "1",
+// 						children: []Node{
+// 							{path: "1", key: 1011},
+// 							{path: "0", key: 1010},
+// 						},
+// 					},
+// 					{
+// 						path: "0",
+// 						children: []Node{
+// 							{path: "9", key: 1009},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"Bug2": {
+// 			node: Node{
+// 				path: "insert/10",
+// 				children: []Node{
+// 					{
+// 						path: "1",
+// 						children: []Node{
+// 							{path: "0", key: 1010},
+// 							{path: "2", key: 1012},
+// 						},
+// 					},
+// 					{
+// 						path: "00",
+// 						key:  1000,
+// 					},
+// 				},
+// 			},
+// 			insertPath: "insert/1011",
+// 			insertKey:  1011,
+// 			expected: Node{
+// 				path: "insert/10",
+// 				children: []Node{
+// 					{
+// 						path: "1",
+// 						children: []Node{
+// 							{path: "1", key: 1011},
+// 							{path: "0", key: 1010},
+// 							{path: "2", key: 1012},
+// 						},
+// 					},
+// 					{
+// 						path: "00",
+// 						key:  1000,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
 
-	for name, tt := range tests {
-		tt := tt
-		main.Run(name, func(t *testing.T) {
-			actual := tt.node.Insert(tt.insertPath, tt.insertKey)
-			require.Equal(t, tt.expected, actual)
-		})
-	}
-}
+// 	for name, tt := range tests {
+// 		tt := tt
+// 		main.Run(name, func(t *testing.T) {
+// 			actual := tt.node.Insert(tt.insertPath, tt.insertKey)
+// 			require.Equal(t, tt.expected, actual)
+// 		})
+// 	}
+// }
 
-func TestNode_InsertDynamic(main *testing.T) {
-	type test struct {
-		node       Node
-		insertPath string
-		insertKey  uint64
-		expected   Node
-	}
+// func TestNode_InsertDynamic(main *testing.T) {
+// 	type test struct {
+// 		node       Node
+// 		insertPath string
+// 		insertKey  uint64
+// 		expected   Node
+// 	}
 
-	tests := map[string]test{
-		"ToEmpty0": {
-			node:       Node{},
-			insertPath: "/{foo}",
-			insertKey:  1,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{
-						kind: param,
-						path: "{foo}",
-						key:  1,
-					},
-				},
-			},
-		},
-		"ToEmpty1": {
-			node:       Node{},
-			insertPath: "/foo/{bar}",
-			insertKey:  1,
-			expected: Node{
-				path: "/foo/",
-				children: []Node{
-					{
-						kind: param,
-						path: "{bar}",
-						key:  1,
-					},
-				},
-			},
-		},
-		"ToEmpty2": {
-			node:       Node{},
-			insertPath: "/foo/{bar}/baz",
-			insertKey:  1,
-			expected: Node{
-				path: "/foo/",
-				children: []Node{
-					{
-						kind: param,
-						path: "{bar}",
-						children: []Node{
-							{
-								path: "/baz",
-								key:  1,
-							},
-						},
-					},
-				},
-			},
-		},
-		"SplitCurrent": {
-			node: Node{
-				path: "/foo/bar",
-				key:  1,
-			},
-			insertPath: "/foo/{name}",
-			insertKey:  2,
-			expected: Node{
-				path: "/foo/",
-				key:  0,
-				children: []Node{
-					{
-						kind: param,
-						path: "{name}",
-						key:  2,
-					},
-					{
-						path: "bar",
-						key:  1,
-					},
-				},
-			},
-		},
-		"SplitCurrentParam": {
-			node: Node{
-				path: "/foo/",
-				children: []Node{
-					{
-						kind: param,
-						path: "{bar}",
-						key:  1,
-					},
-				},
-			},
-			insertPath: "/foo/{bar}/name",
-			insertKey:  2,
-			expected: Node{
-				path: "/foo/",
-				key:  0,
-				children: []Node{
-					{
-						kind: param,
-						path: "{bar}",
-						key:  1,
-						children: []Node{
-							{
-								path: "/name",
-								key:  2,
-							},
-						},
-					},
-				},
-			},
-		},
-		"ShorterAsCurrent": {
-			node: Node{
-				path: "/",
-				key:  0,
-				children: []Node{
-					{
-						kind: param,
-						path: "{foo}",
-						key:  1,
-					},
-				},
-			},
-			insertPath: "/fo",
-			insertKey:  2,
-			expected: Node{
-				path: "/",
-				key:  0,
-				children: []Node{
-					{
-						path: "fo",
-						key:  2,
-					},
-					{
-						kind: param,
-						path: "{foo}",
-						key:  1,
-					},
-				},
-			},
-		},
-		"SameAsCurrent": {
-			node: Node{
-				path: "/",
-				key:  0,
-				children: []Node{
-					{
-						kind: param,
-						path: "{foo}",
-						key:  1,
-					},
-				},
-			},
-			insertPath: "/{foo}",
-			insertKey:  1,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{
-						kind: param,
-						path: "{foo}",
-						key:  1,
-					},
-				},
-			},
-		},
-		"NewParamChild": {
-			node: Node{
-				path: "/",
-				children: []Node{
-					{path: "foo", key: 1},
-					{path: "bar", key: 2},
-				},
-			},
-			insertPath: "/{ololo}",
-			insertKey:  3,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{kind: param, path: "{ololo}", key: 3},
-					{path: "foo", key: 1},
-					{path: "bar", key: 2},
-				},
-			},
-		},
-		"NewParamChildChild1": {
-			node: Node{
-				path: "/",
-				children: []Node{
-					{
-						path: "foo/",
-						key:  1,
-						children: []Node{
-							{path: "bar", key: 2},
-						},
-					},
-				},
-			},
-			insertPath: "/foo/{ololo}",
-			insertKey:  3,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{
-						path: "foo/",
-						key:  1,
-						children: []Node{
-							{kind: param, path: "{ololo}", key: 3},
-							{path: "bar", key: 2},
-						},
-					},
-				},
-			},
-		},
-		"NewParamChildChild2": {
-			node: Node{
-				path: "/",
-				children: []Node{
-					{
-						path: "foo/",
-						key:  1,
-						children: []Node{
-							{path: "bar", key: 2},
-						},
-					},
-				},
-			},
-			insertPath: "/foo/{ololo}/aaa",
-			insertKey:  3,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{
-						path: "foo/",
-						key:  1,
-						children: []Node{
-							{
-								kind: param,
-								path: "{ololo}",
-								children: []Node{
-									{
-										path: "/aaa",
-										key:  3,
-									},
-								},
-							},
-							{path: "bar", key: 2},
-						},
-					},
-				},
-			},
-		},
-		"NewParamChildChild3": {
-			node: Node{
-				path: "/bar/",
-				children: []Node{
-					{
-						path: "1",
-						key:  2,
-					},
-					{
-						path: "0",
-						key:  1,
-					},
-				},
-			},
-			insertPath: "/bar/{param}",
-			insertKey:  3,
-			expected: Node{
-				path: "/bar/",
-				children: []Node{
-					{
-						kind: param,
-						path: "{param}",
-						key:  3,
-					},
-					{
-						path: "1",
-						key:  2,
-					},
-					{
-						path: "0",
-						key:  1,
-					},
-				},
-			},
-		},
-		"Wildcard": {
-			node:       Node{},
-			insertPath: "/{*foo}",
-			insertKey:  1,
-			expected: Node{
-				path: "/",
-				children: []Node{
-					{
-						kind: param,
-						path: "{*foo}",
-						key:  1,
-					},
-				},
-			},
-		},
-	}
+// 	tests := map[string]test{
+// 		"ToEmpty0": {
+// 			node:       Node{},
+// 			insertPath: "/{foo}",
+// 			insertKey:  1,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{foo}",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"ToEmpty1": {
+// 			node:       Node{},
+// 			insertPath: "/foo/{bar}",
+// 			insertKey:  1,
+// 			expected: Node{
+// 				path: "/foo/",
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{bar}",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"ToEmpty2": {
+// 			node:       Node{},
+// 			insertPath: "/foo/{bar}/baz",
+// 			insertKey:  1,
+// 			expected: Node{
+// 				path: "/foo/",
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{bar}",
+// 						children: []Node{
+// 							{
+// 								path: "/baz",
+// 								key:  1,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"SplitCurrent": {
+// 			node: Node{
+// 				path: "/foo/bar",
+// 				key:  1,
+// 			},
+// 			insertPath: "/foo/{name}",
+// 			insertKey:  2,
+// 			expected: Node{
+// 				path: "/foo/",
+// 				key:  0,
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{name}",
+// 						key:  2,
+// 					},
+// 					{
+// 						path: "bar",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"SplitCurrentParam": {
+// 			node: Node{
+// 				path: "/foo/",
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{bar}",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 			insertPath: "/foo/{bar}/name",
+// 			insertKey:  2,
+// 			expected: Node{
+// 				path: "/foo/",
+// 				key:  0,
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{bar}",
+// 						key:  1,
+// 						children: []Node{
+// 							{
+// 								path: "/name",
+// 								key:  2,
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"ShorterAsCurrent": {
+// 			node: Node{
+// 				path: "/",
+// 				key:  0,
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{foo}",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 			insertPath: "/fo",
+// 			insertKey:  2,
+// 			expected: Node{
+// 				path: "/",
+// 				key:  0,
+// 				children: []Node{
+// 					{
+// 						path: "fo",
+// 						key:  2,
+// 					},
+// 					{
+// 						kind: param,
+// 						path: "{foo}",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"SameAsCurrent": {
+// 			node: Node{
+// 				path: "/",
+// 				key:  0,
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{foo}",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 			insertPath: "/{foo}",
+// 			insertKey:  1,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{foo}",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"NewParamChild": {
+// 			node: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{path: "foo", key: 1},
+// 					{path: "bar", key: 2},
+// 				},
+// 			},
+// 			insertPath: "/{ololo}",
+// 			insertKey:  3,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{kind: param, path: "{ololo}", key: 3},
+// 					{path: "foo", key: 1},
+// 					{path: "bar", key: 2},
+// 				},
+// 			},
+// 		},
+// 		"NewParamChildChild1": {
+// 			node: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						path: "foo/",
+// 						key:  1,
+// 						children: []Node{
+// 							{path: "bar", key: 2},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			insertPath: "/foo/{ololo}",
+// 			insertKey:  3,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						path: "foo/",
+// 						key:  1,
+// 						children: []Node{
+// 							{kind: param, path: "{ololo}", key: 3},
+// 							{path: "bar", key: 2},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"NewParamChildChild2": {
+// 			node: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						path: "foo/",
+// 						key:  1,
+// 						children: []Node{
+// 							{path: "bar", key: 2},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			insertPath: "/foo/{ololo}/aaa",
+// 			insertKey:  3,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						path: "foo/",
+// 						key:  1,
+// 						children: []Node{
+// 							{
+// 								kind: param,
+// 								path: "{ololo}",
+// 								children: []Node{
+// 									{
+// 										path: "/aaa",
+// 										key:  3,
+// 									},
+// 								},
+// 							},
+// 							{path: "bar", key: 2},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"NewParamChildChild3": {
+// 			node: Node{
+// 				path: "/bar/",
+// 				children: []Node{
+// 					{
+// 						path: "1",
+// 						key:  2,
+// 					},
+// 					{
+// 						path: "0",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 			insertPath: "/bar/{param}",
+// 			insertKey:  3,
+// 			expected: Node{
+// 				path: "/bar/",
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{param}",
+// 						key:  3,
+// 					},
+// 					{
+// 						path: "1",
+// 						key:  2,
+// 					},
+// 					{
+// 						path: "0",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 		"Wildcard": {
+// 			node:       Node{},
+// 			insertPath: "/{*foo}",
+// 			insertKey:  1,
+// 			expected: Node{
+// 				path: "/",
+// 				children: []Node{
+// 					{
+// 						kind: param,
+// 						path: "{*foo}",
+// 						key:  1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
 
-	for name, tt := range tests {
-		tt := tt
+// 	for name, tt := range tests {
+// 		tt := tt
 
-		main.Run(name, func(t *testing.T) {
-			actual := tt.node.Insert(tt.insertPath, tt.insertKey)
-			require.Equal(t, tt.expected, actual)
-		})
-	}
-}
+// 		main.Run(name, func(t *testing.T) {
+// 			actual := tt.node.Insert(tt.insertPath, tt.insertKey)
+// 			require.Equal(t, tt.expected, actual)
+// 		})
+// 	}
+// }
 
 func TestNode_InsertInvalid(main *testing.T) {
 	n := Node{}

--- a/stdrouter/router_test.go
+++ b/stdrouter/router_test.go
@@ -197,7 +197,7 @@ func TestRouter_HandleComplexParametrizedRouting(main *testing.T) {
 			})
 		}
 	})
-	main.Run("June2024_Bug", func(t *testing.T) {
+	main.Run("WhenParametrizedRouteRegisteredBefore_OK", func(t *testing.T) {
 		r := stdrouter.New()
 
 		// wildcard param test
@@ -217,20 +217,11 @@ func TestRouter_HandleComplexParametrizedRouting(main *testing.T) {
 				method:    "POST", // can be any method
 				path:      "/api/v1/foo/bar",
 				status:    http.StatusOK,
-				handlerID: 1,
-				params: map[string]interface{}{
-					stdrouter.HandlerKeyUserValue: uint64(1),
-				},
 			},
 			{
 				method:    "POST", // can be any method
 				path:      "/api/something/else",
 				status:    http.StatusOK,
-				handlerID: 2,
-				params: map[string]interface{}{
-					stdrouter.HandlerKeyUserValue: uint64(2),
-					"path":                        "something/else",
-				},
 			},
 		}
 
@@ -253,7 +244,7 @@ func TestRouter_HandleComplexParametrizedRouting(main *testing.T) {
 			})
 		}
 	})
-	main.Run("June2024_Bug_2", func(t *testing.T) {
+	main.Run("WhenParametrizedRouteRegisteredAfter_OK", func(t *testing.T) {
 		r := stdrouter.New()
 
 		// wildcard param test
@@ -273,20 +264,11 @@ func TestRouter_HandleComplexParametrizedRouting(main *testing.T) {
 				method:    "POST", // can be any method
 				path:      "/api/v1/foo/bar",
 				status:    http.StatusOK,
-				handlerID: 1,
-				params: map[string]interface{}{
-					stdrouter.HandlerKeyUserValue: uint64(1),
-				},
 			},
 			{
 				method:    "POST", // can be any method
 				path:      "/api/something/else",
 				status:    http.StatusOK,
-				handlerID: 2,
-				params: map[string]interface{}{
-					stdrouter.HandlerKeyUserValue: uint64(2),
-					"path":                        "something/else",
-				},
 			},
 		}
 

--- a/stdrouter/router_test.go
+++ b/stdrouter/router_test.go
@@ -253,6 +253,62 @@ func TestRouter_HandleComplexParametrizedRouting(main *testing.T) {
 			})
 		}
 	})
+	main.Run("June2024_Bug_2", func(t *testing.T) {
+		r := stdrouter.New()
+
+		// wildcard param test
+		require.NoError(t, r.Add(stdrouter.MethodAny, "/api/v1/foo/bar", 1))
+		require.NoError(t, r.Add(stdrouter.MethodAny, "/api/{*path}", 2))
+
+		type test struct {
+			status    int
+			params    map[string]interface{}
+			method    string
+			path      string
+			handlerID uint64
+		}
+
+		tests := []test{
+			{
+				method:    "POST", // can be any method
+				path:      "/api/v1/foo/bar",
+				status:    http.StatusOK,
+				handlerID: 1,
+				params: map[string]interface{}{
+					stdrouter.HandlerKeyUserValue: uint64(1),
+				},
+			},
+			{
+				method:    "POST", // can be any method
+				path:      "/api/something/else",
+				status:    http.StatusOK,
+				handlerID: 2,
+				params: map[string]interface{}{
+					stdrouter.HandlerKeyUserValue: uint64(2),
+					"path":                        "something/else",
+				},
+			},
+		}
+
+		r.GlobalHandler = stdrouter.HandlerFunc(func(rw http.ResponseWriter, req *http.Request, params stdrouter.Params) {
+			rw.WriteHeader(http.StatusOK)
+		})
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(fmt.Sprintf("%s-%d", tt.method, tt.handlerID), func(t *testing.T) {
+				req := &http.Request{}
+				req.Method = tt.method
+				req.URL = &url.URL{}
+				req.URL.Path = tt.path
+				rw := &httptest.ResponseRecorder{}
+
+				r.ServeHTTP(rw, req)
+
+				assert.Equal(t, tt.status, rw.Result().StatusCode)
+			})
+		}
+	})
 }
 
 func TestRouter_Handle(main *testing.T) {


### PR DESCRIPTION
Fix for bug when parametrised handler registration order affects the actual routing.
This fix guarantees that param route will be first in n.children slice, so parametrised search works as expected.
Added test cases to cover this.

This change also affects order of adding non-parametrised children to a node, but, from what I understand, it's not important so should not affect routing